### PR TITLE
storage: when reapplying a blob, also check the cached blobs

### DIFF
--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -312,6 +312,9 @@ func (s *storageImageDestination) ReapplyBlob(blobinfo types.BlobInfo) (types.Bl
 	if layerList, ok := s.Layers[blobinfo.Digest]; !ok || len(layerList) < 1 {
 		b, err := s.imageRef.transport.store.ImageBigData(s.ID, blobinfo.Digest.String())
 		if err != nil {
+			if blob, ok := s.BlobData[blobinfo.Digest]; ok {
+				return types.BlobInfo{Digest: blobinfo.Digest, Size: int64(len(blob))}, nil
+			}
 			return types.BlobInfo{}, err
 		}
 		return types.BlobInfo{Digest: blobinfo.Digest, Size: int64(len(b))}, nil


### PR DESCRIPTION
When reapplying a blob to a storageImageDestination, if we didn't already create an image entry to hold not-layer blobs as big data items, we won't be able to read them.  In that case we should check the cached set of blobs for a matching blob.

Current `containers/image` does this differently than the version we're using here in the 1.9 branch, so this change is not necessary in later branches.